### PR TITLE
Feat:支持通过指定config与自定义config内容，决定每个群开放和关闭哪些功能

### DIFF
--- a/src/main/java/com/raccoon/qqbot/QqbotApplication.java
+++ b/src/main/java/com/raccoon/qqbot/QqbotApplication.java
@@ -1,8 +1,10 @@
 package com.raccoon.qqbot;
 
+import com.raccoon.qqbot.config.GroupFunctionConfig;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -12,6 +14,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @EnableScheduling
 @EnableAsync
 @EnableWebMvc
+@EnableConfigurationProperties({GroupFunctionConfig.class})
 public class QqbotApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/raccoon/qqbot/config/GroupFunctionConfig.java
+++ b/src/main/java/com/raccoon/qqbot/config/GroupFunctionConfig.java
@@ -1,0 +1,40 @@
+package com.raccoon.qqbot.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author 千里夜雨
+ */
+@Component
+@ConfigurationProperties("group.function")
+public class GroupFunctionConfig {
+    /**
+     * 指定从id到config选择之间的关系
+     */
+    public Map<Long, String> configs;
+
+    /**
+     * 指定各个config支持多少的方法
+     */
+    public Map<String, List<Integer>> functions;
+
+    public Map<Long, String> getConfigs() {
+        return configs;
+    }
+
+    public void setConfigs(Map<Long, String> configs) {
+        this.configs = configs;
+    }
+
+    public Map<String, List<Integer>> getFunctions() {
+        return functions;
+    }
+
+    public void setFunctions(Map<String, List<Integer>> functions) {
+        this.functions = functions;
+    }
+}

--- a/src/main/java/com/raccoon/qqbot/data/action/UserAction.java
+++ b/src/main/java/com/raccoon/qqbot/data/action/UserAction.java
@@ -1,5 +1,6 @@
 package com.raccoon.qqbot.data.action;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.raccoon.qqbot.config.MiraiConfig;
 import net.mamoe.mirai.contact.Member;
 import net.mamoe.mirai.contact.MemberPermission;
@@ -8,7 +9,11 @@ import net.mamoe.mirai.message.data.At;
 import net.mamoe.mirai.message.data.PlainText;
 import net.mamoe.mirai.message.data.QuoteReply;
 
-import static com.raccoon.qqbot.data.action.UserAction.Permission.allWelcome;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.raccoon.qqbot.data.action.UserAction.Permission.ALL_WELCOME;
 
 public class UserAction {
     private Type type;
@@ -95,8 +100,8 @@ public class UserAction {
             userAction.type = type;
             userAction.senderId = event.getSender().getId();
             userAction.targetId = targetId;
-            userAction.senderPermission = GetPermission(event.getSender());
-            userAction.targetPermission = GetPermission(event.getGroup().get(targetId));
+            userAction.senderPermission = getPermission(event.getSender());
+            userAction.targetPermission = getPermission(event.getGroup().get(targetId));
             userAction.actionStr = actionStr;
         }
 
@@ -144,7 +149,7 @@ public class UserAction {
             quoteAction.setSenderId(event.getSender().getId());
             quoteAction.setQuoteReply(quoteReply);
             quoteAction.setActionStr(actionStr);
-            quoteAction.setSenderPermission(GetPermission(event.getSender()));
+            quoteAction.setSenderPermission(getPermission(event.getSender()));
         }
 
         return quoteAction;
@@ -184,7 +189,7 @@ public class UserAction {
         return type;
     }
 
-    public static Permission GetPermission(Member member) {
+    public static Permission getPermission(Member member) {
         Permission memberPermission = Permission.MEMBER;
         if (member.getPermission() == MemberPermission.ADMINISTRATOR) {
             memberPermission = Permission.ADMINISTRATOR;
@@ -253,7 +258,7 @@ public class UserAction {
         ADMINISTRATOR(3),
         OWNER(4);
 
-        final static Permission[] allWelcome = new Permission[]{Permission.OWNER, Permission.ADMINISTRATOR, Permission.CODING_EMPEROR,
+        final static Permission[] ALL_WELCOME = new Permission[]{Permission.OWNER, Permission.ADMINISTRATOR, Permission.CODING_EMPEROR,
                 Permission.CODING_TIGER, Permission.MEMBER};
 
         private int privilege;
@@ -302,17 +307,17 @@ public class UserAction {
         CONFIG_HOLIDAY(10, "过节", KeywordMatchType.START_WITH, new Permission[]{Permission.OWNER, Permission.ADMINISTRATOR}),
         CONFIG_WORK(11, "上班", KeywordMatchType.START_WITH, new Permission[]{Permission.OWNER, Permission.ADMINISTRATOR}),
         // 上票
-        VOTE(12, "投", KeywordMatchType.START_WITH, allWelcome),
+        VOTE(12, "投", KeywordMatchType.START_WITH, ALL_WELCOME),
         // 处刑
         EXECUTION(13, "执行", KeywordMatchType.START_WITH, new Permission[]{Permission.OWNER, Permission.ADMINISTRATOR, Permission.CODING_EMPEROR}),
         // 计算票数
-        VOTE_COUNT(14, "计票", KeywordMatchType.START_WITH, allWelcome),
+        VOTE_COUNT(14, "计票", KeywordMatchType.START_WITH, ALL_WELCOME),
         ;
 
-        private int type;
-        private KeywordMatchType keywordMatchType;
-        private Permission[] permissionArray;
-        private String keyword;
+        private final int type;
+        private final KeywordMatchType keywordMatchType;
+        private final Permission[] permissionArray;
+        private final String keyword;
 
         Type(int type, String keyword, KeywordMatchType keywordMatchType, Permission[] permissionArray) {
             this.type = type;
@@ -321,38 +326,36 @@ public class UserAction {
             this.permissionArray = permissionArray;
         }
 
+        @JsonValue
         public int getType() {
             return type;
-        }
-
-        public void setType(int type) {
-            this.type = type;
         }
 
         public Permission[] getPermissionArray() {
             return permissionArray;
         }
 
-        public void setPermissionArray(Permission[] permissionArray) {
-            this.permissionArray = permissionArray;
-        }
-
         public String getKeyword() {
             return keyword;
         }
 
-        public void setKeyword(String keyword) {
-            this.keyword = keyword;
-        }
-
         public boolean hasPermission(Member member) {
-            Permission memberPermission = GetPermission(member);
+            Permission memberPermission = getPermission(member);
             for (Permission permission : permissionArray) {
                 if (permission == memberPermission) {
                     return true;
                 }
             }
             return false;
+        }
+
+        final private static Map<Integer, Type> map = new HashMap<>();
+        static {
+            Arrays.stream(Type.values()).forEach(o -> map.put(o.type, o));
+        }
+
+        public static Type valueOf(int type){
+            return Type.map.get(type);
         }
     }
 

--- a/src/main/java/com/raccoon/qqbot/service/FunctionControlService.java
+++ b/src/main/java/com/raccoon/qqbot/service/FunctionControlService.java
@@ -1,0 +1,48 @@
+package com.raccoon.qqbot.service;
+
+import com.raccoon.qqbot.config.GroupFunctionConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.util.*;
+
+import static com.raccoon.qqbot.data.action.UserAction.*;
+
+@Service
+public class FunctionControlService {
+
+    @Autowired
+    GroupFunctionConfig groupFunctionConfig;
+
+    Map<Long, String> groupToConfigMap;
+    final Map<String, Set<Type>> configToFunctionMap = new HashMap<>();
+
+    @PostConstruct
+    public void init(){
+        groupToConfigMap = groupFunctionConfig.configs;
+        Map<String, List<Integer>> map = groupFunctionConfig.functions;
+        for(Map.Entry<String, List<Integer>> e:map.entrySet()){
+            String configId = e.getKey();
+            List<Integer> v = e.getValue();
+            Set<Type> types = new HashSet<>();
+            v.forEach(o -> types.add(Type.valueOf(o)));
+            configToFunctionMap.put(configId, types);
+        }
+    }
+
+    private final static String DEFAULT_CONFIG_NAME = "config0";
+    public boolean checkGroupSupportThisFunction(Long groupId, Type type){
+        String config = groupToConfigMap.get(groupId);
+        if (config == null){
+            config = DEFAULT_CONFIG_NAME;
+        }
+        Collection<Type> types = configToFunctionMap.get(config);
+        if (types == null){
+            // 没有定义该配置
+            return false;
+        }else{
+            return types.contains(type);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,7 @@ spring.redis.timeout=10000ms
 # QCLOUD
 #com.raccoon.qqbot.qcloud.secretid=### CONFIG ###
 #com.raccoon.qqbot.qcloud.secretkey=### CONFIG ###
+## GROUP FUNCTION
+group.function.configs.552449242=config1
+group.function.functions.config0=0,1,2,3,4,5,6,7,8,9,10,11
+group.function.functions.config1=0,12,13,14


### PR DESCRIPTION
从properties读配置到bean中的操作我只用yaml试了试，感觉好像没问题（逃）
现在默认的config0为 0到11 的所有功能，
config1为 12到14 的三个功能（0是默认有的）。也就是陶片放逐法的三个功能。
暂时没有支持通过 config = config0 + config1 这样的拼装功能。
可以通过在.properties中修改config0的列表去改变默认配置。
需要为群指定非默认的config时，在.properties中插入新的config列表，指定功能数字即可。
FunctionControlService负责做功能的权限校验。名字感觉起得都不是太规范就是了……